### PR TITLE
Fix `plainify` bugs with quoted string & emojis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
     - `plainify`
         - Fix double scanning of inlines of wiki-links
         - Remove footnotes (\#3)
+        - Fix `Quoted` inline processing
 
 ## 0.1.0.0
 

--- a/src/Commonmark/Extensions/WikiLink.hs
+++ b/src/Commonmark/Extensions/WikiLink.hs
@@ -263,7 +263,7 @@ wikilinkSpec =
  TODO: extend on top of plainify from heist-extra
 -}
 plainify :: [B.Inline] -> Text
-plainify = W.query plainify' . W.walk (mapMaybe removeInlineNotes)
+plainify = plainify' . W.walk (mapMaybe removeInlineNotes)
   where
     removeInlineNotes :: B.Inline -> Maybe B.Inline
     removeInlineNotes = \case

--- a/src/Commonmark/Extensions/WikiLink.hs
+++ b/src/Commonmark/Extensions/WikiLink.hs
@@ -272,8 +272,8 @@ plainify = plainify' . W.walk (concatMap preprocess)
       -- Expand quotes (W.query can't deal with them without repetition)
       B.Quoted qt x ->
         case qt of
-          B.SingleQuote -> [B.Str "'"] <> x <> [B.Str "'"]
-          B.DoubleQuote -> [B.Str "\""] <> x <> [B.Str "\""]
+          B.SingleQuote -> [B.Str "‘"] <> x <> [B.Str "’"]
+          B.DoubleQuote -> [B.Str "“"] <> x <> [B.Str "”"]
       a -> one a
 
 plainify' :: [B.Inline] -> Text

--- a/src/Commonmark/Extensions/WikiLink.hs
+++ b/src/Commonmark/Extensions/WikiLink.hs
@@ -263,12 +263,18 @@ wikilinkSpec =
  TODO: extend on top of plainify from heist-extra
 -}
 plainify :: [B.Inline] -> Text
-plainify = plainify' . W.walk (mapMaybe removeInlineNotes)
+plainify = plainify' . W.walk (concatMap preprocess)
   where
-    removeInlineNotes :: B.Inline -> Maybe B.Inline
-    removeInlineNotes = \case
-      B.Note {} -> Nothing
-      a -> Just a
+    preprocess :: B.Inline -> [B.Inline]
+    preprocess = \case
+      -- Remove footnotes
+      B.Note {} -> []
+      -- Expand quotes (W.query can't deal with them without repetition)
+      B.Quoted qt x ->
+        case qt of
+          B.SingleQuote -> [B.Str "'"] <> x <> [B.Str "'"]
+          B.DoubleQuote -> [B.Str "\""] <> x <> [B.Str "\""]
+      a -> one a
 
 plainify' :: [B.Inline] -> Text
 plainify' = W.query $ \case
@@ -277,6 +283,11 @@ plainify' = W.query $ \case
   B.Space -> " "
   B.SoftBreak -> " "
   B.LineBreak -> " "
+  B.Quoted qt x ->
+    let s = plainify' x
+     in case qt of
+          B.SingleQuote -> "'" <> s <> "'"
+          B.DoubleQuote -> "\"" <> s <> "\""
   -- TODO: if fmt is html, we should strip the html tags
   B.RawInline _fmt s -> s
   -- Ignore "wrapper" inlines like span.

--- a/test/Commonmark/Extensions/WikiLinkSpec.hs
+++ b/test/Commonmark/Extensions/WikiLinkSpec.hs
@@ -39,6 +39,8 @@ spec = do
         plainify <$> parseMdPara1 "Hello[^1] World.\n\n[^1]: Some footnote." `shouldBe` Right "Hello World."
       it "with quotes" $ do
         plainify <$> parseMdPara1 "Foo \"Bar\" - MySite" `shouldBe` Right "Foo \"Bar\" - MySite"
+      it "with emoji" $ do
+        plainify <$> parseMdPara1 "Emoji :writing_hand:" `shouldBe` Right "Emoji ✍️"
 
 -- | Parse Markdown with our wikilink parser enabled
 parseMd :: Text -> Either Text Pandoc

--- a/test/Commonmark/Extensions/WikiLinkSpec.hs
+++ b/test/Commonmark/Extensions/WikiLinkSpec.hs
@@ -37,6 +37,8 @@ spec = do
         plainify <$> parseMdPara1 "[[World]]" `shouldBe` Right "[[World]]"
       it "with footnote" $ do
         plainify <$> parseMdPara1 "Hello[^1] World.\n\n[^1]: Some footnote." `shouldBe` Right "Hello World."
+      it "with quotes" $ do
+        plainify <$> parseMdPara1 "Foo \"Bar\" - MySite" `shouldBe` Right "Foo \"Bar\" - MySite"
 
 -- | Parse Markdown with our wikilink parser enabled
 parseMd :: Text -> Either Text Pandoc

--- a/test/Commonmark/Extensions/WikiLinkSpec.hs
+++ b/test/Commonmark/Extensions/WikiLinkSpec.hs
@@ -38,7 +38,7 @@ spec = do
       it "with footnote" $ do
         plainify <$> parseMdPara1 "Hello[^1] World.\n\n[^1]: Some footnote." `shouldBe` Right "Hello World."
       it "with quotes" $ do
-        plainify <$> parseMdPara1 "Foo \"Bar\" - MySite" `shouldBe` Right "Foo \"Bar\" - MySite"
+        plainify <$> parseMdPara1 "Foo \"Bar\" - MySite" `shouldBe` Right "Foo “Bar” - MySite"
       it "with emoji" $ do
         plainify <$> parseMdPara1 "Emoji :writing_hand:" `shouldBe` Right "Emoji ✍️"
 


### PR DESCRIPTION
Quotes are getting lost:

<img width="582" alt="image" src="https://github.com/user-attachments/assets/9cce7c45-a26a-4676-983c-44c73ff96eec" />

Emoji's get doubled:

<img width="408" alt="image" src="https://github.com/user-attachments/assets/7dc3d8df-983d-4307-94f9-0d60e79d0d75" />
