### PR TITLE
Export wikilinkUrl for wikilink resolution

### DIFF
--- a/src/Commonmark/Extensions/WikiLink.hs
+++ b/src/Commonmark/Extensions/WikiLink.hs
@@ -16,6 +16,7 @@ module Commonmark.Extensions.WikiLink (
   -- * Converting wikilinks
   wikilinkInline,
   wikiLinkInlineRendered,
+  wikilinkUrl,
 
   -- * Commonmark parser spec
   wikilinkSpec,

--- a/test/Commonmark/Extensions/WikiLinkSpec.hs
+++ b/test/Commonmark/Extensions/WikiLinkSpec.hs
@@ -2,12 +2,19 @@ module Commonmark.Extensions.WikiLinkSpec where
 
 import Commonmark.Extensions.WikiLink
 import Commonmark.Simple
+import Data.List.NonEmpty qualified as NE
+import Network.URI.Slug qualified as Slug
 import Test.Hspec
 import Text.Pandoc.Definition
 
 spec :: Spec
 spec = do
   describe "commonmark-wikilink" $ do
+    it "wikilinkUrl" $ do
+      let decode s = fromMaybe (error "bad slug") $ Slug.decodeSlug s
+          slugs = decode "Foo" NE.:| [decode "Bar"]
+          wl = mkWikiLinkFromSlugs slugs
+      wikilinkUrl wl `shouldBe` "Foo/Bar"
     it "basic" $ do
       let res = snd <$> parseMarkdownWithFrontMatter @Text fullMarkdownSpec "<fp>" "Hello [[World]]."
           expected = Pandoc mempty [Para [Str "Hello", Space, Str "[[World]]."]]


### PR DESCRIPTION
Export `wikilinkUrl` function from `Commonmark.Extensions.WikiLink` module.
This allows consumers to extract the URL from a `WikiLink` value, which is useful for building resolution maps.

Also added a test case in `test/Commonmark/Extensions/WikiLinkSpec.hs` to verify the export and functionality.

---
*PR created automatically by Jules for task [7689097402921709998](https://jules.google.com/task/7689097402921709998) started by @srid*