### PR TITLE
Decode HTML entities inside wikilinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+## Unreleased
+
+- Decode HTML entities in wikilink custom titles while preserving entity escapes in references as link text, not anchor delimiters ([#9](https://github.com/srid/commonmark-wikilink/pull/9)).
+
 ## 0.2.0.0
 
 - Fixes

--- a/commonmark-wikilink.cabal
+++ b/commonmark-wikilink.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               commonmark-wikilink
-version:            0.2.0.0
+version:            0.3.0.0
 license:            MIT
 copyright:          2022 Sridhar Ratnakumar
 maintainer:         srid@srid.ca

--- a/src/Commonmark/Extensions/WikiLink.hs
+++ b/src/Commonmark/Extensions/WikiLink.hs
@@ -29,6 +29,7 @@ module Commonmark.Extensions.WikiLink (
 ) where
 
 import Commonmark qualified as CM
+import Commonmark.Entity qualified as CE
 import Commonmark.Pandoc qualified as CP
 import Commonmark.TokParsers qualified as CT
 import Control.Monad (liftM2)
@@ -132,8 +133,12 @@ wikilinkUrl :: WikiLink -> Text
 wikilinkUrl =
   T.intercalate "/" . fmap Slug.unSlug . toList . unWikiLink
 
+wikilinkLinkUrl :: WikiLink -> Text
+wikilinkLinkUrl =
+  T.intercalate "/" . fmap Slug.encodeSlug . toList . unWikiLink
+
 wikilinkInline :: WikiLinkType -> WikiLink -> B.Inlines -> B.Inlines
-wikilinkInline typ wl = B.linkWith attrs (wikilinkUrl wl) ""
+wikilinkInline typ wl = B.linkWith attrs (wikilinkLinkUrl wl) ""
   where
     attrs = ("", [], [(htmlAttr, show typ)])
 
@@ -229,24 +234,23 @@ wikilinkSpec =
       replicateM_ 2 $ CT.symbol '['
       P.notFollowedBy (CT.symbol '[')
       url <-
-        CM.untokenize <$> many (satisfyNoneOf [isPipe, isAnchor, isClose])
+        entityAwareText [isPipe, isAnchor, isClose]
       wl <- mkWikiLinkFromUrl url
       -- We ignore the anchor until https://github.com/srid/emanote/discussions/105
       _anchor <-
         M.optional $
-          CM.untokenize
-            <$> ( CT.symbol '#'
-                    *> many (satisfyNoneOf [isPipe, isClose])
-                )
+          CT.symbol '#'
+            *> entityAwareText [isPipe, isClose]
       title <-
         M.optional $
           -- TODO: Should parse as inline so link text can be formatted?
-          CM.untokenize
-            <$> ( CT.symbol '|'
-                    *> many (satisfyNoneOf [isClose])
-                )
+          CT.symbol '|'
+            *> entityAwareText [isClose]
       replicateM_ 2 $ CT.symbol ']'
       return $ wikilink typ wl (fmap CM.str title)
+    entityAwareText toks =
+      CM.untokenize
+        <$> many (P.try CE.pEntity <|> satisfyNoneOf toks)
     satisfyNoneOf toks =
       CT.satisfyTok $ \t -> not $ any (\tok -> tok t) toks
     isAnchor =

--- a/test/Commonmark/Extensions/WikiLinkSpec.hs
+++ b/test/Commonmark/Extensions/WikiLinkSpec.hs
@@ -25,6 +25,30 @@ spec = do
                   ]
               ]
       res `shouldBe` Right expected
+    it "decodes HTML entities in custom titles" $ do
+      parseMdPara1 "[[category-theory-spivak-2014|Spivak&nbsp;(2014)]]"
+        `shouldBe` Right
+          [ Link
+              ("", [], [("data-wikilink-type", "WikiLinkNormal")])
+              [Str "Spivak\160(2014)"]
+              ("category-theory-spivak-2014", "")
+          ]
+    it "decodes numeric HTML entities in custom titles" $ do
+      parseMdPara1 "[[paper|Section &#35;1]]"
+        `shouldBe` Right
+          [ Link
+              ("", [], [("data-wikilink-type", "WikiLinkNormal")])
+              [Str "Section", Space, Str "#1"]
+              ("paper", "")
+          ]
+    it "keeps numeric HTML entities in references distinct from anchors" $ do
+      parseMdPara1 "[[chapter-&#35;1|number]]"
+        `shouldBe` Right
+          [ Link
+              ("", [], [("data-wikilink-type", "WikiLinkNormal")])
+              [Str "number"]
+              ("chapter-%231", "")
+          ]
     describe "plainify" $ do
       it "basic" $ do
         plainify <$> parseMdPara1 "Hello" `shouldBe` Right "Hello"


### PR DESCRIPTION
**Wiki link labels now decode CommonMark entities** before they become Pandoc inline text, so custom titles like `[[note|Spivak&nbsp;(2014)]]` render the intended non-breaking space instead of literal `&nbsp;` text. This matches regular Markdown link behavior and fixes the parser bug reported in srid/emanote#441.

**Reference parsing now consumes entities before checking wikilink delimiters**, which keeps numeric entities such as `&#35;` from being mistaken for the optional `#anchor` separator. The rendered Pandoc link destination is URL-encoded for those parsed wiki targets, while the `WikiLink` value remains decoded for downstream resolution.

### Try it locally

```sh
nix build github:srid/commonmark-wikilink/fix-wikilink-html-entities
```

_Generated by [`/do`](https://github.com/srid/agency) on Codex (model `gpt-5`)._