### PR TITLE
feat: preserve #anchor in wikilinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 
 ## Unreleased
 
+- Preserve `#anchor` in wikilinks so `[[note#heading]]` renders as `note#heading` instead of dropping the fragment ([srid/emanote#105](https://github.com/srid/emanote/discussions/105)).
+    - **Breaking**: `wikilinkInline` now takes `Maybe Anchor`; `mkWikiLinkFromInline` returns `(WikiLink, Maybe Anchor, [Inline])`.
 - Decode HTML entities in wikilink custom titles while preserving entity escapes in references as link text, not anchor delimiters ([#9](https://github.com/srid/commonmark-wikilink/pull/9)).
 
 ## 0.2.0.0

--- a/commonmark-wikilink.cabal
+++ b/commonmark-wikilink.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               commonmark-wikilink
-version:            0.3.0.0
+version:            0.4.0.0
 license:            MIT
 copyright:          2022 Sridhar Ratnakumar
 maintainer:         srid@srid.ca

--- a/src/Commonmark/Extensions/WikiLink.hs
+++ b/src/Commonmark/Extensions/WikiLink.hs
@@ -313,9 +313,10 @@ plainify' = W.query $ \case
   -- with custom text, we return "" because W.query will walk the child
   -- nodes and pick the title up there.
   (mkWikiLinkFromInline -> Just (wl, manc, customText)) ->
-    if null customText
-      then "[[" <> wikilinkUrl wl <> anchorSuffix manc <> "]]"
-      else ""
+    let target = wikilinkUrl wl <> anchorSuffix manc
+     in if null customText
+          then "[[" <> target <> "]]"
+          else ""
   -- Ignore the rest of AST nodes, as they are recursively defined in terms of
   -- `Inline` which `W.query` will traverse again.
   _ -> ""

--- a/src/Commonmark/Extensions/WikiLink.hs
+++ b/src/Commonmark/Extensions/WikiLink.hs
@@ -23,6 +23,7 @@ module Commonmark.Extensions.WikiLink (
   -- * Anchors in URLs
   Anchor,
   anchorSuffix,
+  dropUrlAnchor,
 
   -- * Pandoc helper
   plainify,

--- a/src/Commonmark/Extensions/WikiLink.hs
+++ b/src/Commonmark/Extensions/WikiLink.hs
@@ -75,11 +75,11 @@ mkWikiLinkFromUrl s = do
   slugs <- maybe empty pure $ nonEmpty $ Slug.decodeSlug <$> T.splitOn "/" s
   pure $ WikiLink slugs
 
-mkWikiLinkFromInline :: B.Inline -> Maybe (WikiLink, [B.Inline])
+mkWikiLinkFromInline :: B.Inline -> Maybe (WikiLink, Maybe Anchor, [B.Inline])
 mkWikiLinkFromInline inl = do
   B.Link (_id, _class, otherAttrs) is (url, tit) <- pure inl
-  (Left (_, wl), _manchor) <- delineateLink (otherAttrs <> one ("title", tit)) url
-  pure (wl, is)
+  (Left (_, wl), manchor) <- delineateLink (otherAttrs <> one ("title", tit)) url
+  pure (wl, manchor, is)
 
 -- | An URL anchor without the '#'
 newtype Anchor = Anchor Text
@@ -109,7 +109,6 @@ delineateLink (Map.fromList -> attrs) url = do
   where
     wikiLink = do
       wlType :: WikiLinkType <- readMaybe . toString <=< Map.lookup htmlAttr $ attrs
-      -- Ignore anchors until https://github.com/srid/emanote/discussions/105
       let (s, manc) = dropUrlAnchor url
       wl <- mkWikiLinkFromUrl s
       pure (Left (wlType, wl), manc)
@@ -137,21 +136,22 @@ wikilinkLinkUrl :: WikiLink -> Text
 wikilinkLinkUrl =
   T.intercalate "/" . fmap Slug.encodeSlug . toList . unWikiLink
 
-wikilinkInline :: WikiLinkType -> WikiLink -> B.Inlines -> B.Inlines
-wikilinkInline typ wl = B.linkWith attrs (wikilinkLinkUrl wl) ""
+wikilinkInline :: WikiLinkType -> WikiLink -> Maybe Anchor -> B.Inlines -> B.Inlines
+wikilinkInline typ wl manc = B.linkWith attrs (wikilinkLinkUrl wl <> anchorSuffix manc) ""
   where
     attrs = ("", [], [(htmlAttr, show typ)])
 
 wikiLinkInlineRendered :: B.Inline -> Maybe Text
 wikiLinkInlineRendered x = do
-  (wl, inl) <- mkWikiLinkFromInline x
+  (wl, manc, inl) <- mkWikiLinkFromInline x
+  let target = wikilinkUrl wl <> anchorSuffix manc
   pure $ case nonEmpty inl of
-    Nothing -> show wl
+    Nothing -> "[[" <> target <> "]]"
     Just _ ->
       let inlStr = plainify inl
-       in if inlStr == wikilinkUrl wl
-            then show wl
-            else "[[" <> wikilinkUrl wl <> "|" <> plainify inl <> "]]"
+       in if inlStr == target
+            then "[[" <> target <> "]]"
+            else "[[" <> target <> "|" <> plainify inl <> "]]"
 
 {- | Return the various ways to link to a route (ignoring ext)
 
@@ -201,11 +201,11 @@ htmlAttr :: Text
 htmlAttr = "data-wikilink-type"
 
 class HasWikiLink il where
-  wikilink :: WikiLinkType -> WikiLink -> Maybe il -> il
+  wikilink :: WikiLinkType -> WikiLink -> Maybe Anchor -> Maybe il -> il
 
 instance HasWikiLink (CP.Cm b B.Inlines) where
-  wikilink typ wl il =
-    CP.Cm $ wikilinkInline typ wl $ maybe mempty CP.unCm il
+  wikilink typ wl manc il =
+    CP.Cm $ wikilinkInline typ wl manc $ maybe mempty CP.unCm il
 
 {- | Like `Commonmark.Extensions.Wikilinks.wikilinkSpec` but Zettelkasten-friendly.
 
@@ -236,18 +236,17 @@ wikilinkSpec =
       url <-
         entityAwareText [isPipe, isAnchor, isClose]
       wl <- mkWikiLinkFromUrl url
-      -- We ignore the anchor until https://github.com/srid/emanote/discussions/105
-      _anchor <-
+      manchor <-
         M.optional $
           CT.symbol '#'
-            *> entityAwareText [isPipe, isClose]
+            *> (Anchor <$> entityAwareText [isPipe, isClose])
       title <-
         M.optional $
           -- TODO: Should parse as inline so link text can be formatted?
           CT.symbol '|'
             *> entityAwareText [isClose]
       replicateM_ 2 $ CT.symbol ']'
-      return $ wikilink typ wl (fmap CM.str title)
+      return $ wikilink typ wl manchor (fmap CM.str title)
     entityAwareText toks =
       CM.untokenize
         <$> many (P.try CE.pEntity <|> satisfyNoneOf toks)
@@ -308,14 +307,14 @@ plainify' = W.query $ \case
   B.Span _ _ -> ""
   -- TODO: How to wrap math stuff here?
   B.Math _mathTyp s -> s
-  -- Wiki-links must be displayed using its show instance (which returns its
-  -- human-readable representation)
-  (mkWikiLinkFromInline -> Just (wl, customText)) ->
+  -- Wiki-links must be displayed in their source-equivalent form so a
+  -- "[[note#heading]]" without inner text round-trips to that same string;
+  -- with custom text, we return "" because W.query will walk the child
+  -- nodes and pick the title up there.
+  (mkWikiLinkFromInline -> Just (wl, manc, customText)) ->
     if null customText
-      then -- We will display raw wikilink; ideally, though, we want to display the title.
-        show wl
-      else -- Because `W.query` will walk the child nodes once again, so we don't have to do anything.
-        ""
+      then "[[" <> wikilinkUrl wl <> anchorSuffix manc <> "]]"
+      else ""
   -- Ignore the rest of AST nodes, as they are recursively defined in terms of
   -- `Inline` which `W.query` will traverse again.
   _ -> ""

--- a/src/Commonmark/Extensions/WikiLink.hs
+++ b/src/Commonmark/Extensions/WikiLink.hs
@@ -8,6 +8,7 @@ module Commonmark.Extensions.WikiLink (
   -- * Parsing wikilinks
   mkWikiLinkFromSlugs,
   mkWikiLinkFromInline,
+  parseWikiLinkUrl,
   delineateLink,
 
   -- * Wikilink candidates
@@ -81,6 +82,20 @@ mkWikiLinkFromInline inl = do
   B.Link (_id, _class, otherAttrs) is (url, tit) <- pure inl
   (Left (_, wl), manchor) <- delineateLink (otherAttrs <> one ("title", tit)) url
   pure (wl, manchor, is)
+
+{- | Parse a raw user-supplied URL string (e.g. @"foo/bar#section"@) into
+a 'WikiLink' plus optional 'Anchor'. Mirrors what 'delineateLink' does
+for Pandoc 'B.Link' inputs but doesn't require the wikilink-type
+attribute — for non-Markdown callers (MCP tools, CLI, JSON APIs) that
+just receive the inside-the-brackets text and need the same anchor
+semantics as the renderer.
+-}
+parseWikiLinkUrl :: Text -> Maybe (WikiLink, Maybe Anchor)
+parseWikiLinkUrl raw = do
+  let (wlPart, manchor) = dropUrlAnchor raw
+  guard $ not $ T.null wlPart
+  wl <- mkWikiLinkFromUrl wlPart
+  pure (wl, manchor)
 
 -- | An URL anchor without the '#'
 newtype Anchor = Anchor Text

--- a/test/Commonmark/Extensions/WikiLinkSpec.hs
+++ b/test/Commonmark/Extensions/WikiLinkSpec.hs
@@ -49,6 +49,55 @@ spec = do
               [Str "number"]
               ("chapter-%231", "")
           ]
+    describe "anchors in wikilinks" $ do
+      it "preserves anchor in cross-file heading link" $ do
+        parseMdPara1 "[[note#heading]]"
+          `shouldBe` Right
+            [ Link
+                ("", [], [("data-wikilink-type", "WikiLinkNormal")])
+                []
+                ("note#heading", "")
+            ]
+      it "preserves anchor with custom title" $ do
+        parseMdPara1 "[[note#heading|See heading]]"
+          `shouldBe` Right
+            [ Link
+                ("", [], [("data-wikilink-type", "WikiLinkNormal")])
+                [Str "See", Space, Str "heading"]
+                ("note#heading", "")
+            ]
+      it "preserves anchor in embed link" $ do
+        parseMdPara1 "![[note#heading]]"
+          `shouldBe` Right
+            [ Link
+                ("", [], [("data-wikilink-type", "WikiLinkEmbed")])
+                []
+                ("note#heading", "")
+            ]
+      it "preserves anchor in branch link" $ do
+        parseMdPara1 "[[note#heading]]#"
+          `shouldBe` Right
+            [ Link
+                ("", [], [("data-wikilink-type", "WikiLinkBranch")])
+                []
+                ("note#heading", "")
+            ]
+      it "preserves anchor in tag link" $ do
+        parseMdPara1 "#[[note#heading]]"
+          `shouldBe` Right
+            [ Link
+                ("", [], [("data-wikilink-type", "WikiLinkTag")])
+                []
+                ("note#heading", "")
+            ]
+      it "parses anchor with spaces" $ do
+        parseMdPara1 "[[note#hello world]]"
+          `shouldBe` Right
+            [ Link
+                ("", [], [("data-wikilink-type", "WikiLinkNormal")])
+                []
+                ("note#hello world", "")
+            ]
     describe "plainify" $ do
       it "basic" $ do
         plainify <$> parseMdPara1 "Hello" `shouldBe` Right "Hello"
@@ -59,6 +108,10 @@ spec = do
         plainify <$> parseMdPara1 "[Hello](https://example.com)" `shouldBe` Right "Hello"
       it "with wikilink" $ do
         plainify <$> parseMdPara1 "[[World]]" `shouldBe` Right "[[World]]"
+      it "with wikilink anchor" $ do
+        plainify <$> parseMdPara1 "[[note#heading]]" `shouldBe` Right "[[note#heading]]"
+      it "with wikilink anchor and custom title yields the custom text" $ do
+        plainify <$> parseMdPara1 "[[note#heading|See heading]]" `shouldBe` Right "See heading"
       it "with footnote" $ do
         plainify <$> parseMdPara1 "Hello[^1] World.\n\n[^1]: Some footnote." `shouldBe` Right "Hello World."
       it "with quotes" $ do

--- a/test/Commonmark/Extensions/WikiLinkSpec.hs
+++ b/test/Commonmark/Extensions/WikiLinkSpec.hs
@@ -98,6 +98,19 @@ spec = do
                 []
                 ("note#hello world", "")
             ]
+    describe "parseWikiLinkUrl" $ do
+      let url s = bimap show show <$> parseWikiLinkUrl s
+      it "rejects an empty string" $ do
+        parseWikiLinkUrl "" `shouldBe` Nothing
+      it "parses a single-segment target with no anchor" $ do
+        url "note" `shouldBe` Just ("[[note]]", "Nothing")
+      it "parses a slash-separated target with no anchor" $ do
+        url "foo/bar" `shouldBe` Just ("[[foo/bar]]", "Nothing")
+      it "splits target from anchor on the first #" $ do
+        url "note#heading"
+          `shouldBe` Just ("[[note]]", "Just \"heading\"")
+      it "rejects an anchor-only URL (anchor with empty wikilink target)" $ do
+        parseWikiLinkUrl "#heading" `shouldBe` Nothing
     describe "plainify" $ do
       it "basic" $ do
         plainify <$> parseMdPara1 "Hello" `shouldBe` Right "Hello"

--- a/test/Commonmark/Extensions/WikiLinkSpec.hs
+++ b/test/Commonmark/Extensions/WikiLinkSpec.hs
@@ -99,7 +99,9 @@ spec = do
                 ("note#hello world", "")
             ]
     describe "parseWikiLinkUrl" $ do
-      let url s = bimapF show show (parseWikiLinkUrl s)
+      let url s = do
+            (wl, manc) <- parseWikiLinkUrl s
+            pure (show @Text wl, show @Text manc)
       it "rejects an empty string" $ do
         parseWikiLinkUrl "" `shouldBe` Nothing
       it "parses a single-segment target with no anchor" $ do

--- a/test/Commonmark/Extensions/WikiLinkSpec.hs
+++ b/test/Commonmark/Extensions/WikiLinkSpec.hs
@@ -99,7 +99,7 @@ spec = do
                 ("note#hello world", "")
             ]
     describe "parseWikiLinkUrl" $ do
-      let url s = bimap show show <$> parseWikiLinkUrl s
+      let url s = bimapF show show (parseWikiLinkUrl s)
       it "rejects an empty string" $ do
         parseWikiLinkUrl "" `shouldBe` Nothing
       it "parses a single-segment target with no anchor" $ do

--- a/test/Commonmark/Extensions/WikiLinkSpec.hs
+++ b/test/Commonmark/Extensions/WikiLinkSpec.hs
@@ -98,6 +98,19 @@ spec = do
                 []
                 ("note#hello world", "")
             ]
+      -- The link syntax for Obsidian block references (`[[note#^blockid]]`,
+      -- per srid/emanote#105) is just an anchor that starts with a caret. The
+      -- block-ID *definition* syntax (a trailing `^blockid` marker on a
+      -- paragraph or list item) is a separate, non-CommonMark feature and
+      -- belongs to a downstream renderer — not to this parser.
+      it "preserves Obsidian-style ^blockid anchor verbatim" $ do
+        parseMdPara1 "[[note#^565948]]"
+          `shouldBe` Right
+            [ Link
+                ("", [], [("data-wikilink-type", "WikiLinkNormal")])
+                []
+                ("note#^565948", "")
+            ]
     describe "parseWikiLinkUrl" $ do
       let url s = do
             (wl, manc) <- parseWikiLinkUrl s


### PR DESCRIPTION
Wiki-links like `[[note#heading]]` now carry the anchor through to the `B.Link` URL field — the parser captures the fragment, `wikilinkInline` appends it via `anchorSuffix`, and `delineateLink` (already prepared) round-trips it back as `(WikiLink, Just Anchor)`. The two TODOs in this file referencing srid/emanote#105 are now resolved.

Downstream, emanote's `urlResolvingSplice` already appends `mAnchor` to the resolved site-route URL, so no rendering changes are needed there — wiring is just a flake input bump.

## Breaking API changes

- `wikilinkInline` gains a `Maybe Anchor` parameter.
- `mkWikiLinkFromInline` returns `(WikiLink, Maybe Anchor, [Inline])`.
- `HasWikiLink.wikilink` typeclass method takes `Maybe Anchor`. (Unexported, but listed for completeness.)

Version bumped to 0.4.0.0.

## Test coverage

- Anchor preservation across all four wikilink types: `[[a#b]]`, `[[a#b]]#`, `#[[a#b]]`, `![[a#b]]`.
- Custom-title form `[[a#b|c]]`.
- Anchor with spaces.
- `plainify` round-trip for the raw form `[[a#b]]` and the custom-title form.

## Test plan

- [x] `cabal test all` passes on the new branch
- [ ] Downstream emanote integration build green